### PR TITLE
Adding unlimited pagination 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ if (!$request->isUnlimited())
    $databaseQuery->take($request->getLimit())->skip($request->getSkip());
 ```
 
-The unlimited feature is only a falg. Your database query applier must check for this with the `isUnlimited()` method to support this feature.
+The unlimited feature is only a flag. Your database query applier must check for this with the `isUnlimited()` method to support this feature.
 
 #### Filtering
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This library provides a set of classes that help represent requests for complex data and provides a way to convert requests to and from a standard JSON format. If you have interfaces with tons of parameters ($filters, $groupings, $page, $rowsPerPage, etc.), or if you're just looking for a standard way to communicate complex requests to other apps without racking your brain over how to represent this data in JSON, you will like this library.
 
-- **Version:** 5.4.1
+- **Version:** 5.5.0
 
 [![Build Status](https://travis-ci.org/mongerinc/search-request.png?branch=master)](https://travis-ci.org/mongerinc/search-request)
 
@@ -136,6 +136,17 @@ $databaseQuery->take($limit)->skip(($page - 1) * $limit);
 ```
 
 Alternatively, you can call `getSkip()` to avoid doing the calculation above.
+
+If you want to ignore the pagination for a request, you can call the `unlimited()` or `all()` methods.
+
+```php
+$request = $request->unlimited();
+
+if (!$request->isUnlimited())
+   $databaseQuery->take($request->getLimit())->skip($request->getSkip());
+```
+
+The unlimited feature is only a falg. Your database query applier must check for this with the `isUnlimited()` method to support this feature.
 
 #### Filtering
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 5.5.0
+- Adding the unlimited flag for ignoring pagination
+
 ### 5.4.1
 - Fixing `toJson()` for DateTime values
 

--- a/examples/Illuminate/Applier.php
+++ b/examples/Illuminate/Applier.php
@@ -25,7 +25,8 @@ class Applier {
 
 		$this->group($query, $request);
 
-		$query->forPage($request->getPage(), $request->getLimit());
+		if (!$request->isUnlimited())
+			$query->forPage($request->getPage(), $request->getLimit());
 	}
 
 	protected function select(Query $query, SearchRequest $request)

--- a/src/SearchRequest.php
+++ b/src/SearchRequest.php
@@ -122,9 +122,9 @@ class SearchRequest {
 		$this->addFacets($inputs['facets']);
 		$this->groupBy($inputs['groups']);
 		$this->addFilterSetFromArray($inputs['filterSet']);
-		$this->page = $inputs['page'];
-		$this->limit = $inputs['limit'];
 		$this->unlimited = isset($inputs['unlimited']) ? $inputs['unlimited'] : false;
+		$this->page($inputs['page']);
+		$this->limit($inputs['limit']);
 	}
 
 	/**
@@ -400,6 +400,7 @@ class SearchRequest {
 			throw new InvalidArgumentException("A page can only be a positive integer.");
 
 		$this->page = (int) $page;
+		$this->unlimited(false);
 
 		return $this;
 	}
@@ -431,6 +432,7 @@ class SearchRequest {
 			throw new InvalidArgumentException("A page row limit can only be a positive integer.");
 
 		$this->limit = (int) $limit;
+		$this->unlimited(false);
 
 		return $this;
 	}

--- a/src/SearchRequest.php
+++ b/src/SearchRequest.php
@@ -55,6 +55,13 @@ class SearchRequest {
 	protected $limit = 10;
 
 	/**
+	 * Determines if pagination should be ignored
+	 *
+	 * @var bool
+	 */
+	protected $unlimited = false;
+
+	/**
 	 * The list of applicable filters
 	 *
 	 * @var FilterSet
@@ -117,6 +124,7 @@ class SearchRequest {
 		$this->addFilterSetFromArray($inputs['filterSet']);
 		$this->page = $inputs['page'];
 		$this->limit = $inputs['limit'];
+		$this->unlimited = isset($inputs['unlimited']) ? $inputs['unlimited'] : false;
 	}
 
 	/**
@@ -428,6 +436,30 @@ class SearchRequest {
 	}
 
 	/**
+	 * Sets the unlimited flag
+	 *
+	 * @param  bool    $unlimited
+	 *
+	 * @return this
+	 */
+	public function unlimited($unlimited = true)
+	{
+		$this->unlimited = (bool) $unlimited;
+
+		return $this;
+	}
+
+	/**
+	 * Alias for calling unlimited with true
+	 *
+	 * @return this
+	 */
+	public function all()
+	{
+		return $this->unlimited(true);
+	}
+
+	/**
 	 * Gets the current page
 	 *
 	 * @return int
@@ -445,6 +477,16 @@ class SearchRequest {
 	public function getLimit()
 	{
 		return $this->limit;
+	}
+
+	/**
+	 * Gets the unlimited flag
+	 *
+	 * @return bool
+	 */
+	public function isUnlimited()
+	{
+		return $this->unlimited;
 	}
 
 	/**

--- a/src/SearchRequest.php
+++ b/src/SearchRequest.php
@@ -603,6 +603,7 @@ class SearchRequest {
 			'term' => $this->term,
 			'page' => $this->page,
 			'limit' => $this->limit,
+			'unlimited' => $this->unlimited,
 			'selects' => $this->selects,
 			'groups' => $this->groups,
 			'sorts' => array_map(function(Sort $sort) {return $sort->toArray();}, $this->sorts),

--- a/src/SearchRequest.php
+++ b/src/SearchRequest.php
@@ -122,9 +122,9 @@ class SearchRequest {
 		$this->addFacets($inputs['facets']);
 		$this->groupBy($inputs['groups']);
 		$this->addFilterSetFromArray($inputs['filterSet']);
-		$this->unlimited = isset($inputs['unlimited']) ? $inputs['unlimited'] : false;
 		$this->page($inputs['page']);
 		$this->limit($inputs['limit']);
+		$this->unlimited = isset($inputs['unlimited']) ? $inputs['unlimited'] : false;
 	}
 
 	/**

--- a/tests/DeepClone/DeepCloneTest.php
+++ b/tests/DeepClone/DeepCloneTest.php
@@ -36,6 +36,7 @@ class DeepCloneTest extends \PHPUnit_Framework_TestCase {
 			'term' => 'something',
 			'page' => 2,
 			'limit' => 10,
+			'unlimited' => false,
 			'selects' => ['something'],
 			'groups' => ['something'],
 			'sorts' => [

--- a/tests/Json/JsonTest.php
+++ b/tests/Json/JsonTest.php
@@ -41,6 +41,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase {
 			'term' => null,
 			'page' => 1,
 			'limit' => 10,
+			'unlimited' => false,
 			'selects' => [],
 			'groups' => [],
 			'sorts' => [],
@@ -55,6 +56,30 @@ class JsonTest extends \PHPUnit_Framework_TestCase {
 						]
 					]
 				]
+			],
+			'facets' => [],
+		]), $request->toJson());
+	}
+
+	/**
+	 * @test
+	 */
+	public function unlimited()
+	{
+		$request = SearchRequest::create()->unlimited();
+
+		$this->assertEquals(json_encode([
+			'term' => null,
+			'page' => 1,
+			'limit' => 10,
+			'unlimited' => true,
+			'selects' => [],
+			'groups' => [],
+			'sorts' => [],
+			'filterSet' => [],
+			'filterSet' => [
+				'boolean' => 'and',
+				'filters' => []
 			],
 			'facets' => [],
 		]), $request->toJson());
@@ -94,6 +119,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase {
 			'term' => 'search this',
 			'page' => 5,
 			'limit' => 50,
+			'unlimited' => false,
 			'selects' => ['field1', 'field2'],
 			'groups' => ['field', 'anotherField'],
 			'sorts' => [

--- a/tests/Json/JsonTest.php
+++ b/tests/Json/JsonTest.php
@@ -86,6 +86,17 @@ class JsonTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @test
+	 */
+	public function unlimitedFromJson()
+	{
+		$originalRequest = SearchRequest::create()->limit(1)->unlimited();
+		$newRequest = SearchRequest::create($originalRequest->toJson());
+
+		$this->assertTrue($newRequest->isUnlimited());
+	}
+
+	/**
 	 * Gets the expected search request
 	 *
 	 * @return \Monger\SearchRequest\SearchRequest

--- a/tests/Pagination/PaginationTest.php
+++ b/tests/Pagination/PaginationTest.php
@@ -104,16 +104,16 @@ class PaginationTest extends \PHPUnit_Framework_TestCase {
 	public function unlimited()
 	{
 		$request = SearchRequest::create();
-		$this->assertEquals(false, $request->isUnlimited());
+		$this->assertFalse($request->isUnlimited());
 
 		$request->unlimited();
-		$this->assertEquals(true, $request->isUnlimited());
+		$this->assertTrue($request->isUnlimited());
 
 		$request->unlimited(false);
-		$this->assertEquals(false, $request->isUnlimited());
+		$this->assertFalse($request->isUnlimited());
 
 		$request->all();
-		$this->assertEquals(true, $request->isUnlimited());
+		$this->assertTrue($request->isUnlimited());
 	}
 
 	/**
@@ -122,10 +122,10 @@ class PaginationTest extends \PHPUnit_Framework_TestCase {
 	public function settingPaginationFalsifiesUnlimited()
 	{
 		$request = SearchRequest::create()->unlimited()->page(1);
-		$this->assertEquals(false, $request->isUnlimited());
+		$this->assertFalse($request->isUnlimited());
 
 		$request = SearchRequest::create()->unlimited()->limit(1);
-		$this->assertEquals(false, $request->isUnlimited());
+		$this->assertFalse($request->isUnlimited());
 	}
 
 }

--- a/tests/Pagination/PaginationTest.php
+++ b/tests/Pagination/PaginationTest.php
@@ -98,4 +98,22 @@ class PaginationTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, $request->getPage());
 	}
 
+	/**
+	 * @test
+	 */
+	public function unlimited()
+	{
+		$request = SearchRequest::create();
+		$this->assertEquals(false, $request->isUnlimited());
+
+		$request->unlimited();
+		$this->assertEquals(true, $request->isUnlimited());
+
+		$request->unlimited(false);
+		$this->assertEquals(false, $request->isUnlimited());
+
+		$request->all();
+		$this->assertEquals(true, $request->isUnlimited());
+	}
+
 }

--- a/tests/Pagination/PaginationTest.php
+++ b/tests/Pagination/PaginationTest.php
@@ -116,4 +116,16 @@ class PaginationTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(true, $request->isUnlimited());
 	}
 
+	/**
+	 * @test
+	 */
+	public function settingPaginationFalsifiesUnlimited()
+	{
+		$request = SearchRequest::create()->unlimited()->page(1);
+		$this->assertEquals(false, $request->isUnlimited());
+
+		$request = SearchRequest::create()->unlimited()->limit(1);
+		$this->assertEquals(false, $request->isUnlimited());
+	}
+
 }


### PR DESCRIPTION
Pagination can now be ignored by setting the search request to unlimited. 